### PR TITLE
JCF: add explicit requirement on mkdocs-material since it's no longer…

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -24,3 +24,4 @@ Pygments>=2.4
 markdown>=3.2
 pymdown-extensions>=7.0
 mkdocs-material-extensions>=1.0
+mkdocs-material>=7.2.5


### PR DESCRIPTION
… being collected when the documents are being built