### PR TITLE
Johnfreeman/issue31 developer rules

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,9 +2,9 @@
 
 Welcome! The purpose of this website is to provide information on how to use the applications, plugins, base classes, etc. offered by the suite of DUNE DAQ packages. You can learn both how to run the DAQ as well as use various tools to extend its functionality. 
 
-If you're new to DUNE DAQ software and plan to do development, before your first keystroke please read the [developer rules](developer_rules.md). This covers personal conduct related to software development meant to minimize friction between developers, code reversions, etc. 
+If you're new and plan to develop DUNE DAQ software, before your first keystroke please take five minutes to read the [developer rules](developer_rules.md). These cover personal conduct related to software development meant to make the process run as smoothly as possible for all of us.
 
-you'll want to start by reading the [daq-buildtools documentation](packages/daq-buildtools/README.md), which covers [how to set up a development environment](packages/daq-buildtools/README.md#Setup_of_daq-buildtools) and [build a package](packages/daq-buildtools/README.md#Cloning_and_building). Once you've done this, you'll likely want to learn about [how to write DAQ modules](packages/appfwk/README.md#Writing_DAQ_modules) in the [appfwk documentation](packages/appfwk/README.md), units of code which
+To begin developing, you'll then want to start by reading the [daq-buildtools documentation](packages/daq-buildtools/README.md), which covers [how to set up a development environment](packages/daq-buildtools/README.md#Setup_of_daq-buildtools) and [build a package](packages/daq-buildtools/README.md#Cloning_and_building). Once you've done this, you'll likely want to learn about [how to write DAQ modules](packages/appfwk/README.md#Writing_DAQ_modules) in the [appfwk documentation](packages/appfwk/README.md), units of code which
 are meant to perform specific tasks and can be combined to define the overall behavior of a running DAQ application. At some point you may also need to learn about how to create a package from scratch by reading the [daq-cmake documentation](packages/daq-cmake/README.md); this documentation is also very useful for understanding how to get new source code files you've added to compile.  
 
 There are six DUNE DAQ software packages which are used to aid

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Welcome! The purpose of this website is to provide information on how to use the applications, plugins, base classes, etc. offered by the suite of DUNE DAQ packages. You can learn both how to run the DAQ as well as use various tools to extend its functionality. 
 
-If you're new and plan to develop DUNE DAQ software, before your first keystroke please take five minutes to read the [developer rules](developer_rules.md). These cover personal conduct related to software development meant to make the process run as smoothly as possible for all of us.
+If you're new and plan to develop DUNE DAQ software, please take five minutes to read the [developer rules](developer_rules.md). These cover personal conduct related to software development meant to make the process run as smoothly as possible for all of us.
 
 To begin developing, you'll then want to start by reading the [daq-buildtools documentation](packages/daq-buildtools/README.md), which covers [how to set up a development environment](packages/daq-buildtools/README.md#Setup_of_daq-buildtools) and [build a package](packages/daq-buildtools/README.md#Cloning_and_building). Once you've done this, you'll likely want to learn about [how to write DAQ modules](packages/appfwk/README.md#Writing_DAQ_modules) in the [appfwk documentation](packages/appfwk/README.md), units of code which
 are meant to perform specific tasks and can be combined to define the overall behavior of a running DAQ application. At some point you may also need to learn about how to create a package from scratch by reading the [daq-cmake documentation](packages/daq-cmake/README.md); this documentation is also very useful for understanding how to get new source code files you've added to compile.  

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,9 @@
 
 Welcome! The purpose of this website is to provide information on how to use the applications, plugins, base classes, etc. offered by the suite of DUNE DAQ packages. You can learn both how to run the DAQ as well as use various tools to extend its functionality. 
 
-If you're new to DUNE DAQ software, you'll want to start by reading the [daq-buildtools documentation](packages/daq-buildtools/README.md), which covers [how to set up a development environment](packages/daq-buildtools/README.md#Setup_of_daq-buildtools) and [build a package](packages/daq-buildtools/README.md#Cloning_and_building). Once you've done this, you'll likely want to learn about [how to write DAQ modules](packages/appfwk/README.md#Writing_DAQ_modules) in the [appfwk documentation](packages/appfwk/README.md), units of code which
+If you're new to DUNE DAQ software and plan to do development, before your first keystroke please read the [developer rules](developer_rules.md). This covers personal conduct related to software development meant to minimize friction between developers, code reversions, etc. 
+
+you'll want to start by reading the [daq-buildtools documentation](packages/daq-buildtools/README.md), which covers [how to set up a development environment](packages/daq-buildtools/README.md#Setup_of_daq-buildtools) and [build a package](packages/daq-buildtools/README.md#Cloning_and_building). Once you've done this, you'll likely want to learn about [how to write DAQ modules](packages/appfwk/README.md#Writing_DAQ_modules) in the [appfwk documentation](packages/appfwk/README.md), units of code which
 are meant to perform specific tasks and can be combined to define the overall behavior of a running DAQ application. At some point you may also need to learn about how to create a package from scratch by reading the [daq-cmake documentation](packages/daq-cmake/README.md); this documentation is also very useful for understanding how to get new source code files you've added to compile.  
 
 There are six DUNE DAQ software packages which are used to aid

--- a/docs/developer_rules.md
+++ b/docs/developer_rules.md
@@ -1,3 +1,37 @@
 # Developer Rules
 
+Any software project consisting of multiple individuals will suffer if those individuals fail to communicate clearly with one another. A lack of communication can result in code reversions and ill-timed code merges, along with frustration and hurt feelings which can slow the progress of a project. To avoid this, the DUNE DAQ software project has a couple of rules about who to communicate with when code is changed. 
+
+The use cases below are presented in order of increasing need for
+communication. Note that these cases also require adherence to our
+[git versioning system development
+workflow](https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-release/development_workflow_gitflow/),
+though the focus here is on the human communication aspect of software
+development.
+
+## Very minor, obvious changes within a single package
+
+You can make these on your own. There are only a few examples of this:
+* Fixing typos in documentation
+* Removing documentation you're sure is obsolete
+
+## Changes within a single package which don't alter interfaces
+
+These require you to have a second developer take a look at your
+changes before it can be merged into `develop`. Examples include:
+* Adding a feature to a package which users and developers wouldn't notice unless told about it
+* Fixing an obvious bug (e.g. `if (string1 = string2) { ...`)
+* Making simple changes to get non-conforming code to conform to [our styleguide] (packages/styleguide/README.md)
+* Bumping a version in a `CMakeLists.txt` file when you're about to add a new tag
+
+## Changes within a single package which unavoidably affect other developers/users
+
+This type of change needs to be mentioned to the maintainer(s) of the repository in which the changes are being made. To find the maintainer(s) if you're not sure who they are you can look [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-release/team_repos/), though if you're at a point where you're making major changes within a package you probably already should know who they are. Examples of this kind of change are:
+* Altering behavior in a function or function(s) which other parts of the code rely on
+* Refactoring large parts of the codebase after a code review
+
+## Changes across many packages 
+
+A change which is made across many packages all at once needs to be brought to the attention not only of the mantainer(s) of the relevant repos, but also to at least one member of Software Coordination (John Freeman, `jcfree@fnal.gov` and Pengfei Ding, `dingpf@fnal.gov`). [WHAT ELSE?] No examples are needed as this rule is self-explanatory. 
+
 [Back to the DUNE DAQ software documentation homepage](README.md)

--- a/docs/developer_rules.md
+++ b/docs/developer_rules.md
@@ -48,6 +48,6 @@ This type of change needs to be mentioned to the maintainer(s) of the repository
 
 ## Changes across many packages 
 
-A change which is planned to be made across many packages all at once needs to be brought to the attention not only of the maintainer(s) of the relevant repositories, but also to the project has a whole. This means at least one member of Software Coordination (John Freeman, `jcfree@fnal.gov` and Pengfei Ding, `dingpf@fnal.gov`) should be notified, and the planned change announced on the `dunedaq-integration` Slack channel. No examples are needed as this rule is self-explanatory. 
+A change which is planned to be made across many repositories all at once needs to be brought to the attention not only of the maintainers of the repositories, but also to the project as a whole. This means the members of Software Coordination (John Freeman, `jcfree@fnal.gov` and Pengfei Ding, `dingpf@fnal.gov`) should be notified, and the planned change announced on the `dunedaq-integration` Slack channel. No examples are needed as this rule is self-explanatory. 
 
 [Back to the DUNE DAQ software documentation homepage](README.md)

--- a/docs/developer_rules.md
+++ b/docs/developer_rules.md
@@ -1,15 +1,23 @@
 # DUNE DAQ Software Developer Rules
 
-Any software project consisting of multiple individuals will suffer if those individuals fail to communicate clearly with one another. A lack of communication can result in code reversions and ill-timed code merges, along with frustration and hurt feelings which can slow the progress of a project. To avoid this, the DUNE DAQ software project has a couple of rules (with examples) about who to communicate with when you make changes to the code. 
+Any software project consisting of multiple individuals will suffer if those individuals fail to communicate clearly with one another. A lack of communication can result in code reversions and ill-timed code merges, along with frustration and hurt feelings which can slow the progress of a project. To avoid this, the DUNE DAQ software project has rules about who to communicate with when you make different types of changes to the code. 
 
-The use cases below are presented in order of increasing need for
-communication. Note that these cases also require adherence to our
-[git versioning system development
+These different types of code change are described below, each with an
+accompanying communication rule. They are presented in order of
+increasing need for communication, with concrete examples given. Note
+that code changes also require adherence to our [git versioning system
+development
 workflow](https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-release/development_workflow_gitflow/),
 though the focus here is on the human communication aspect of software
 development.
 
-## Minor documentation changes changes within a single package
+Also be aware that while these rules apply for most of the development
+cycle, they don't apply when we're in the one-to-two week official
+release period before a frozen release is cut. During the release
+period, we have just one rule, and it's simple: any planned change
+needs to be announced to the project at our morning release meetings as well as on the `dunedaq-integration` Slack channel. 
+
+## Minor documentation changes within a single package
 
 You can make these on your own. Examples are limited to:
 
@@ -34,12 +42,12 @@ changes before they can be merged into `develop`. Examples include:
 
 This type of change needs to be mentioned to the maintainer(s) of the repository or repositories affected by the changes, including obviously the repository directly modified. To find the maintainer(s) if you're not sure who they are you can look [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-release/team_repos/). Examples of this kind of change are:
 
-* Altering behavior in a function or function(s) which other parts of the code rely on
+* Altering behavior in a function which other parts of the code rely on
 
 * Refactoring large parts of the codebase after a code review
 
 ## Changes across many packages 
 
-A change which is planned to be made across many packages all at once needs to be brought to the attention not only of the mantainer(s) of the relevant repos, but also to at least one member of Software Coordination (John Freeman, `jcfree@fnal.gov` and Pengfei Ding, `dingpf@fnal.gov`). [WHAT ELSE?] No examples are needed as this rule is self-explanatory. 
+A change which is planned to be made across many packages all at once needs to be brought to the attention not only of the maintainer(s) of the relevant repositories, but also to the project has a whole. This means at least one member of Software Coordination (John Freeman, `jcfree@fnal.gov` and Pengfei Ding, `dingpf@fnal.gov`) should be notified, and the planned change announced on the `dunedaq-integration` Slack channel. No examples are needed as this rule is self-explanatory. 
 
 [Back to the DUNE DAQ software documentation homepage](README.md)

--- a/docs/developer_rules.md
+++ b/docs/developer_rules.md
@@ -1,6 +1,6 @@
-# Developer Rules
+# DUNE DAQ Software Developer Rules
 
-Any software project consisting of multiple individuals will suffer if those individuals fail to communicate clearly with one another. A lack of communication can result in code reversions and ill-timed code merges, along with frustration and hurt feelings which can slow the progress of a project. To avoid this, the DUNE DAQ software project has a couple of rules about who to communicate with when code is changed. 
+Any software project consisting of multiple individuals will suffer if those individuals fail to communicate clearly with one another. A lack of communication can result in code reversions and ill-timed code merges, along with frustration and hurt feelings which can slow the progress of a project. To avoid this, the DUNE DAQ software project has a couple of rules (with examples) about who to communicate with when you make changes to the code. 
 
 The use cases below are presented in order of increasing need for
 communication. Note that these cases also require adherence to our
@@ -9,29 +9,37 @@ workflow](https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-release/deve
 though the focus here is on the human communication aspect of software
 development.
 
-## Very minor, obvious changes within a single package
+## Minor documentation changes changes within a single package
 
-You can make these on your own. There are only a few examples of this:
+You can make these on your own. Examples are limited to:
+
 * Fixing typos in documentation
+
 * Removing documentation you're sure is obsolete
 
-## Changes within a single package which don't alter interfaces
+## Changes within a single package which don't affect other code
 
 These require you to have a second developer take a look at your
-changes before it can be merged into `develop`. Examples include:
+changes before they can be merged into `develop`. Examples include:
+
 * Adding a feature to a package which users and developers wouldn't notice unless told about it
+
 * Fixing an obvious bug (e.g. `if (string1 = string2) { ...`)
-* Making simple changes to get non-conforming code to conform to [our styleguide] (packages/styleguide/README.md)
+
+* Making simple changes to get non-conforming code to conform to [our styleguide](packages/styleguide/README.md)
+
 * Bumping a version in a `CMakeLists.txt` file when you're about to add a new tag
 
-## Changes within a single package which unavoidably affect other developers/users
+## Changes within a single package which affect other code, in and/or outside of the package
 
-This type of change needs to be mentioned to the maintainer(s) of the repository in which the changes are being made. To find the maintainer(s) if you're not sure who they are you can look [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-release/team_repos/), though if you're at a point where you're making major changes within a package you probably already should know who they are. Examples of this kind of change are:
+This type of change needs to be mentioned to the maintainer(s) of the repository or repositories affected by the changes, including obviously the repository directly modified. To find the maintainer(s) if you're not sure who they are you can look [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-release/team_repos/). Examples of this kind of change are:
+
 * Altering behavior in a function or function(s) which other parts of the code rely on
+
 * Refactoring large parts of the codebase after a code review
 
 ## Changes across many packages 
 
-A change which is made across many packages all at once needs to be brought to the attention not only of the mantainer(s) of the relevant repos, but also to at least one member of Software Coordination (John Freeman, `jcfree@fnal.gov` and Pengfei Ding, `dingpf@fnal.gov`). [WHAT ELSE?] No examples are needed as this rule is self-explanatory. 
+A change which is planned to be made across many packages all at once needs to be brought to the attention not only of the mantainer(s) of the relevant repos, but also to at least one member of Software Coordination (John Freeman, `jcfree@fnal.gov` and Pengfei Ding, `dingpf@fnal.gov`). [WHAT ELSE?] No examples are needed as this rule is self-explanatory. 
 
 [Back to the DUNE DAQ software documentation homepage](README.md)

--- a/docs/developer_rules.md
+++ b/docs/developer_rules.md
@@ -1,0 +1,3 @@
+# Developer Rules
+
+[Back to the DUNE DAQ software documentation homepage](README.md)


### PR DESCRIPTION
To see what I've written re: communication rules, the relevant page is https://dune-daq-sw.readthedocs.io/en/johnfreeman-issue31_developer_rules/developer_rules/, but then see also how I link to it from near the top of the documentation homepage: https://dune-daq-sw.readthedocs.io/en/johnfreeman-issue31_developer_rules/. Please let me know if you think anything is too strict/not strict enough, or if you have any other comments. 