### PR TITLE
Add Doxygen workflow

### DIFF
--- a/.github/workflows/build-and-publish-doxygen.yml
+++ b/.github/workflows/build-and-publish-doxygen.yml
@@ -1,0 +1,79 @@
+name: Build Doxygen and publish to GitHub pages
+
+on:
+  schedule:
+    - cron: "0 5 * * *"
+
+jobs:
+  build-doxygen:
+    name: build_doxygen
+    runs-on: ubuntu-latest
+    container:
+      image: "ghcr.io/dune-daq/nightly-release-alma9:development_v5"
+    env: 
+      DEV_AREA_NAME: 'dev_area'
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - name: Checkout daq-release
+      uses: actions/checkout@v2
+      with:
+        path: daq-release
+
+    - name: Create dbt area
+      run: |
+        source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
+        setup_dbt latest_v5
+        date_tag=$(date +%y%m%d)
+        release_name=NFD_DEV_${date_tag}_A9
+        cd $GITHUB_WORKSPACE
+        dbt-create -n $release_name ${{ env.DEV_AREA_NAME }}
+        cd ${{ env.DEV_AREA_NAME }}
+        . env.sh
+        echo "DBT_AREA_ROOT=$(echo $DBT_AREA_ROOT)" >> $GITHUB_ENV
+        echo "DBT_AREA_ROOT is $DBT_AREA_ROOT"
+
+    - name: Checkout packages
+      run: |
+        cd $GITHUB_WORKSPACE/daq-release/scripts
+        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o $DBT_AREA_ROOT/sourcecode
+        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o $DBT_AREA_ROOT/sourcecode
+        # triggeralgs doesn't currently work with --codegen-only build; remove for now
+        rm -rf $DBT_AREA_ROOT/sourcecode/triggeralgs
+
+    - name: Build dbt area
+      run: |
+        cd $DBT_AREA_ROOT
+        . env.sh
+        spack load dbe || true
+        spack unload dbe || true
+        dbt-build --codegen-only
+
+    - name: Generate Doxyfile
+      run: |
+        cd $GITHUB_WORKSPACE/daq-release/docs
+        ./doxygen_gen.py
+        # Edit paths in Doxyfile so they can be seen by the Doxygen action container, which uses /github/workspace
+        export DEV_AREA_NAME=${{ env.DEV_AREA_NAME }}
+        sed -i "s|${DBT_AREA_ROOT}|/github/workspace/${{ env.DEV_AREA_NAME }}|g" Doxyfile
+        echo "Contents of Doxyfile INPUT:"
+        cat $GITHUB_WORKSPACE/daq-release/docs/Doxyfile | grep -A 10 "INPUT   "
+
+    - name: Doxygen Action
+      uses: mattnotmitt/doxygen-action@v1.9.8
+      with:
+        working-directory: /github/workspace/daq-release/docs
+        doxyfile-path: './Doxyfile'
+
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./daq-release/docs/docs/html
+        enable_jekyll: false
+        allow_empty_commit: false
+        force_orphan: true
+        publish_branch: gh-pages
+

--- a/.github/workflows/build-and-publish-doxygen.yml
+++ b/.github/workflows/build-and-publish-doxygen.yml
@@ -1,8 +1,9 @@
 name: Build Doxygen and publish to GitHub pages
 
 on:
-  schedule:
-    - cron: "0 5 * * *"
+  workflow_dispatch:
+  #schedule:
+  #  - cron: "0 5 * * *"
 
 jobs:
   build-doxygen:

--- a/.github/workflows/build-and-publish-doxygen.yml
+++ b/.github/workflows/build-and-publish-doxygen.yml
@@ -1,9 +1,8 @@
 name: Build Doxygen and publish to GitHub pages
 
 on:
-  workflow_dispatch:
-  #schedule:
-  #  - cron: "0 5 * * *"
+  schedule:
+    - cron: "0 3 * * *"
 
 jobs:
   build-doxygen:

--- a/.github/workflows/build-and-publish-doxygen.yml
+++ b/.github/workflows/build-and-publish-doxygen.yml
@@ -20,6 +20,8 @@ jobs:
     - name: Checkout daq-release
       uses: actions/checkout@v2
       with:
+        repository: DUNE-DAQ/daq-release
+        ref: 'amogan/doxygen'
         path: daq-release
 
     - name: Create dbt area


### PR DESCRIPTION
This PR adds the workflow `.github/workflows/build-and-publish-doxygen.yml`, which checks out all packages in `coredaq` and `fddaq` into a single area where Doxygen is run. The result is then published to (as of this writing) the [DUNE DAQ GitHub pages](https://dune-daq.github.io/docs/). 

The apparent merge conflicts here are due to the workflow stub in `develop` being incomplete. The changes in this branch should be kept. 

Note that, in its current state, this workflow checks out the related `daq-release` branch `amogan/doxygen`, which includes some Doxygen files and scripts that are useful to have in that repo.  [PR #372 in daq-release](https://github.com/DUNE-DAQ/daq-release/pull/372) will merge those files into the `develop` branch of `daq-release` once finalized, after which this workflow can use the `develop` branch of `daq-release`. 